### PR TITLE
Remove validation categories from rule definitions

### DIFF
--- a/demo/demo_rule.yaml
+++ b/demo/demo_rule.yaml
@@ -72,15 +72,6 @@ column_mapping:
     - "age"
 
 categories:
-  - name: "미분류"
-    id: "unclassified"
-  - name: "데이터 보완 필요"
-    id: "dataValidationRequired"
-    subcategories:
-      - name: "필수 필드 누락"
-        id: "dataValidationRequired_required"
-      - name: "선택적 필드 누락"
-        id: "dataValidationRequired_optional"
   - name: "일반촬영"
     id: "xray"
     target: 10000
@@ -345,74 +336,6 @@ categories:
 
 # 분류 기준 정의
 classification_rules:
-  # 데이터 검증 규칙 (최우선 적용)
-  - category_id: dataValidationRequired
-    priority: 0
-    conditions:
-      - logic: OR
-        conditions:
-          - operator: is_null
-            field: id
-          - operator: is_null
-            field: modality
-          - operator: is_null
-            field: exam_name
-          - operator: is_null
-            field: assign
-          - operator: is_null
-            field: study_date
-          - operator: is_null
-            field: age
-          - operator: is_null
-            field: sex
-          - operator: is_null
-            field: department
-          - operator: is_null
-            field: reading_date
-  - category_id: dataValidationRequired_required
-    parent_category_id: dataValidationRequired
-    priority: 0  # 최우선 적용
-    conditions:
-      - logic: OR
-        conditions:
-          - operator: is_null
-            field: id
-          - operator: is_null
-            field: modality
-          - operator: is_null
-            field: exam_name
-          - operator: is_null
-            field: assign
-          - operator: is_null
-            field: study_date
-  - category_id: dataValidationRequired_optional
-    parent_category_id: dataValidationRequired
-    priority: 1  # 두 번째 우선순위
-    conditions:
-      - logic: AND
-        conditions:
-          # 필수 필드는 모두 있어야 함
-          - operator: not_null
-            field: id
-          - operator: not_null
-            field: modality
-          - operator: not_null
-            field: exam_name
-          - operator: not_null
-            field: assign
-          - operator: not_null
-            field: study_date
-      - logic: OR
-        conditions:
-          # 선택적 필드 중 하나라도 누락
-          - operator: is_null
-            field: age
-          - operator: is_null
-            field: sex
-          - operator: is_null
-            field: department
-          - operator: is_null
-            field: reading_date
   - category_id: xray
     conditions:
       - operator: contains_any

--- a/rules.json
+++ b/rules.json
@@ -3,7 +3,7 @@
     "path": "rules/cauhs-2.yaml",
     "title": "중앙대병원-흑석 2022년이후 입국",
     "description": "중앙대학교병원 / Zetta PACS \nrecord2.radiology.or.kr 사이트 이용하는 2022년 이후 입국자\n2023년 개정 logbook 실태조사\n검사종류/검사명/부서/담당구분 기반 분류\n",
-    "updated_at": "2025-10-17T20:45:02+09:00",
+    "updated_at": "2025-10-18T20:56:53+09:00",
     "author": {
       "name": "김영욱",
       "email": "wooooooooooook@gmail.com"
@@ -139,7 +139,7 @@
     "path": "rules/amc.yaml",
     "title": "서울아산병원-테스트 2022년이후 입국자용",
     "description": "서울아산병원\nrecord2.radiology.or.kr 사이트 이용하는 2022년 이후 입국자\n2023년 개정 logbook 실태조사\n검사종류/검사명/부서/담당구분 기반 분류\n일부 분류 미흡한 버전\n",
-    "updated_at": "2025-10-17T20:45:02+09:00",
+    "updated_at": "2025-10-18T20:56:53+09:00",
     "author": {
       "name": "김영욱",
       "email": "wooooooooooook@gmail.com"
@@ -238,7 +238,7 @@
     "path": "rules/cauhs-2020.yaml",
     "title": "중앙대병원-흑석 2021년 이전 입국",
     "description": "중앙대학교병원용 / Zetta PACS\nrecord2020.radiology.or.kr 사이트 이용하는 2021년 이전 입국자\n2023년 개정 logbook 실태조사\n검사종류/검사명/부서/담당구분 기반 분류\n",
-    "updated_at": "2025-10-17T20:45:02+09:00",
+    "updated_at": "2025-10-18T20:56:53+09:00",
     "author": {
       "name": "김영욱",
       "email": "wooooooooooook@gmail.com"

--- a/rules/amc.yaml
+++ b/rules/amc.yaml
@@ -63,15 +63,6 @@ column_mapping:
     - "age"
 
 categories: # 2023년 개정 logbook 실태조사
-  - name: "미분류"
-    id: "unclassified"
-  - name: "데이터 보완 필요"
-    id: "dataValidationRequired"
-    subcategories:
-      - name: "필수 필드 누락"
-        id: "dataValidationRequired_required"
-      - name: "선택적 필드 누락"
-        id: "dataValidationRequired_optional"
   - name: "일반촬영"
     id: "xray"
     target: 10000
@@ -337,65 +328,6 @@ categories: # 2023년 개정 logbook 실태조사
 # 분류 기준 정의
 classification_rules:
   # 데이터 검증 규칙 (최우선 적용)
-  - category_id: dataValidationRequired
-    priority: 0
-    conditions:
-      - logic: OR
-        conditions:
-          - operator: is_null
-            field: id
-          - operator: is_null
-            field: modality
-          - operator: is_null
-            field: exam_name
-          - operator: is_null
-            field: assign
-          - operator: is_null
-            field: reading_date
-  - category_id: dataValidationRequired_required
-    parent_category_id: dataValidationRequired
-    priority: 0  # 최우선 적용
-    conditions:
-      - logic: OR
-        conditions:
-          - operator: is_null
-            field: id
-          - operator: is_null
-            field: modality
-          - operator: is_null
-            field: exam_name
-          - operator: is_null
-            field: assign
-          - operator: is_null
-            field: reading_date
-          - operator: is_null
-            field: age
-          - operator: is_null
-            field: sex
-  - category_id: dataValidationRequired_optional
-    parent_category_id: dataValidationRequired
-    priority: 1  # 두 번째 우선순위
-    conditions:
-      - logic: AND
-        conditions:
-          # 필수 필드는 모두 있어야 함
-          - operator: not_null
-            field: id
-          - operator: not_null
-            field: modality
-          - operator: not_null
-            field: exam_name
-          - operator: not_null
-            field: assign
-          - operator: not_null
-            field: study_date
-      - logic: OR
-        conditions:
-          # 선택적 필드 중 하나라도 누락
-          - operator: is_null
-            field: age
-          - operator: is_null
-            field: sex
   - category_id: xray
     conditions:
       - operator: equals

--- a/rules/cauhs-2.yaml
+++ b/rules/cauhs-2.yaml
@@ -73,15 +73,6 @@ column_mapping:
     - "age"
 
 categories:
-  - name: "미분류"
-    id: "unclassified"
-  - name: "데이터 보완 필요"
-    id: "dataValidationRequired"
-    subcategories:
-      - name: "필수 필드 누락"
-        id: "dataValidationRequired_required"
-      - name: "선택적 필드 누락"
-        id: "dataValidationRequired_optional"
   - name: "일반촬영"
     id: "xray"
     target: 10000
@@ -346,74 +337,6 @@ categories:
 
 # 분류 기준 정의
 classification_rules:
-  # 데이터 검증 규칙 (최우선 적용)
-  - category_id: dataValidationRequired
-    priority: 0
-    conditions:
-      - logic: OR
-        conditions:
-          - operator: is_null
-            field: id
-          - operator: is_null
-            field: modality
-          - operator: is_null
-            field: exam_name
-          - operator: is_null
-            field: assign
-          - operator: is_null
-            field: study_date
-          - operator: is_null
-            field: age
-          - operator: is_null
-            field: sex
-          - operator: is_null
-            field: department
-          - operator: is_null
-            field: reading_date
-  - category_id: dataValidationRequired_required
-    parent_category_id: dataValidationRequired
-    priority: 0  # 최우선 적용
-    conditions:
-      - logic: OR
-        conditions:
-          - operator: is_null
-            field: id
-          - operator: is_null
-            field: modality
-          - operator: is_null
-            field: exam_name
-          - operator: is_null
-            field: assign
-          - operator: is_null
-            field: study_date
-  - category_id: dataValidationRequired_optional
-    parent_category_id: dataValidationRequired
-    priority: 1  # 두 번째 우선순위
-    conditions:
-      - logic: AND
-        conditions:
-          # 필수 필드는 모두 있어야 함
-          - operator: not_null
-            field: id
-          - operator: not_null
-            field: modality
-          - operator: not_null
-            field: exam_name
-          - operator: not_null
-            field: assign
-          - operator: not_null
-            field: study_date
-      - logic: OR
-        conditions:
-          # 선택적 필드 중 하나라도 누락
-          - operator: is_null
-            field: age
-          - operator: is_null
-            field: sex
-          - operator: is_null
-            field: department
-          - operator: is_null
-            field: reading_date
   - category_id: xray
     conditions:
       - operator: contains_any

--- a/rules/cauhs-2020.yaml
+++ b/rules/cauhs-2020.yaml
@@ -73,15 +73,6 @@ column_mapping:
     - "age"
 
 categories:
-  - name: "미분류"
-    id: "unclassified"
-  - name: "데이터 보완 필요"
-    id: "dataValidationRequired"
-    subcategories:
-      - name: "필수 필드 누락"
-        id: "dataValidationRequired_required"
-      - name: "선택적 필드 누락"
-        id: "dataValidationRequired_optional"
   - name: "일반촬영"
     id: "xray"
     target: 10000
@@ -346,74 +337,6 @@ categories:
 
 # 분류 기준 정의
 classification_rules:
-  # 데이터 검증 규칙 (최우선 적용)
-  - category_id: dataValidationRequired
-    priority: 0
-    conditions:
-      - logic: OR
-        conditions:
-          - operator: is_null
-            field: id
-          - operator: is_null
-            field: modality
-          - operator: is_null
-            field: exam_name
-          - operator: is_null
-            field: assign
-          - operator: is_null
-            field: study_date
-          - operator: is_null
-            field: age
-          - operator: is_null
-            field: sex
-          - operator: is_null
-            field: department
-          - operator: is_null
-            field: reading_date
-  - category_id: dataValidationRequired_required
-    parent_category_id: dataValidationRequired
-    priority: 0  # 최우선 적용
-    conditions:
-      - logic: OR
-        conditions:
-          - operator: is_null
-            field: id
-          - operator: is_null
-            field: modality
-          - operator: is_null
-            field: exam_name
-          - operator: is_null
-            field: assign
-          - operator: is_null
-            field: study_date
-  - category_id: dataValidationRequired_optional
-    parent_category_id: dataValidationRequired
-    priority: 1  # 두 번째 우선순위
-    conditions:
-      - logic: AND
-        conditions:
-          # 필수 필드는 모두 있어야 함
-          - operator: not_null
-            field: id
-          - operator: not_null
-            field: modality
-          - operator: not_null
-            field: exam_name
-          - operator: not_null
-            field: assign
-          - operator: not_null
-            field: study_date
-      - logic: OR
-        conditions:
-          # 선택적 필드 중 하나라도 누락
-          - operator: is_null
-            field: age
-          - operator: is_null
-            field: sex
-          - operator: is_null
-            field: department
-          - operator: is_null
-            field: reading_date
   - category_id: xray
     conditions:
       - operator: contains_any


### PR DESCRIPTION
## Summary
- remove the 미분류 및 데이터 보완 필요 카테고리를 demo 및 병원 규칙 파일에서 삭제
- 제거된 카테고리에 대응하던 classification_rules 항목들도 함께 정리

## Testing
- pnpm format && pnpm lint *(fails: No package manifest found)*
- pnpm check *(fails: No package manifest found)*
- pnpm test *(fails: No package manifest found)*

------
https://chatgpt.com/codex/tasks/task_e_68f3791635a8832ca713ab136d6b1008