### PR TITLE
핵의학 분류를 하위 카테고리 기반으로 구성

### DIFF
--- a/demo/demo_rule.yaml
+++ b/demo/demo_rule.yaml
@@ -847,15 +847,7 @@ classification_rules:
         field: modality
         value: "XA"
   - category_id: nuclearmedicine
-    conditions:
-      - logic: OR
-        conditions:
-          - operator: contains
-            field: modality
-            value: "NM"
-          - operator: contains
-            field: modality
-            value: "PT"
+    composed_by_subcategories: true
   - category_id: nuclearmedicine_pet
     parent_category_id: nuclearmedicine
     conditions:

--- a/rules.json
+++ b/rules.json
@@ -3,7 +3,7 @@
     "path": "rules/cauhs-2.yaml",
     "title": "중앙대병원-흑석 2022년이후 입국",
     "description": "중앙대학교병원 / Zetta PACS \nrecord2.radiology.or.kr 사이트 이용하는 2022년 이후 입국자\n2023년 개정 logbook 실태조사\n검사종류/검사명/부서/담당구분 기반 분류\n",
-    "updated_at": "2025-10-18T20:57:11+09:00",
+    "updated_at": "2025-10-19T14:13:02+09:00",
     "author": {
       "name": "김영욱",
       "email": "wooooooooooook@gmail.com"
@@ -139,7 +139,7 @@
     "path": "rules/amc.yaml",
     "title": "서울아산병원-테스트 2022년이후 입국자용",
     "description": "서울아산병원\nrecord2.radiology.or.kr 사이트 이용하는 2022년 이후 입국자\n2023년 개정 logbook 실태조사\n검사종류/검사명/부서/담당구분 기반 분류\n일부 분류 미흡한 버전\n",
-    "updated_at": "2025-10-18T20:57:11+09:00",
+    "updated_at": "2025-10-19T14:13:02+09:00",
     "author": {
       "name": "김영욱",
       "email": "wooooooooooook@gmail.com"
@@ -238,7 +238,7 @@
     "path": "rules/cauhs-2020.yaml",
     "title": "중앙대병원-흑석 2021년 이전 입국",
     "description": "중앙대학교병원용 / Zetta PACS\nrecord2020.radiology.or.kr 사이트 이용하는 2021년 이전 입국자\n2023년 개정 logbook 실태조사\n검사종류/검사명/부서/담당구분 기반 분류\n",
-    "updated_at": "2025-10-18T20:57:11+09:00",
+    "updated_at": "2025-10-19T14:13:02+09:00",
     "author": {
       "name": "김영욱",
       "email": "wooooooooooook@gmail.com"

--- a/rules/amc.yaml
+++ b/rules/amc.yaml
@@ -824,15 +824,7 @@ classification_rules:
         field: modality
         value: "DS"
   - category_id: nuclearmedicine
-    conditions:
-      - logic: OR
-        conditions:
-          - operator: contains
-            field: modality
-            value: "NM"
-          - operator: contains
-            field: modality
-            value: "PT"
+    composed_by_subcategories: true
   - category_id: nuclearmedicine_pet
     parent_category_id: nuclearmedicine
     conditions:

--- a/rules/cauhs-2.yaml
+++ b/rules/cauhs-2.yaml
@@ -848,15 +848,7 @@ classification_rules:
         field: modality
         value: "XA"
   - category_id: nuclearmedicine
-    conditions:
-      - logic: OR
-        conditions:
-          - operator: contains
-            field: modality
-            value: "NM"
-          - operator: contains
-            field: modality
-            value: "PT"
+    composed_by_subcategories: true
   - category_id: nuclearmedicine_pet
     parent_category_id: nuclearmedicine
     conditions:

--- a/rules/cauhs-2020.yaml
+++ b/rules/cauhs-2020.yaml
@@ -847,15 +847,7 @@ classification_rules:
         field: modality
         value: "XA"
   - category_id: nuclearmedicine
-    conditions:
-      - logic: OR
-        conditions:
-          - operator: contains
-            field: modality
-            value: "NM"
-          - operator: contains
-            field: modality
-            value: "PT"
+    composed_by_subcategories: true
   - category_id: nuclearmedicine_pet
     parent_category_id: nuclearmedicine
     conditions:


### PR DESCRIPTION
## Summary
- rules 및 demo 규칙 파일에서 핵의학 상위 분류를 하위 분류로만 구성되도록 `composed_by_subcategories: true`로 전환했습니다.
- PET 및 일반 핵의학 세부 분류 조건을 유지해 핵의학 검사가 하위 규칙을 통해 분류되도록 정비했습니다.

## Testing
- `pnpm format && pnpm lint` *(실패: No package.json was found in "/workspace/logbookmanager_repository".)*
- `pnpm check` *(실패: No package.json was found in "/workspace/logbookmanager_repository".)*
- `pnpm test` *(실패: No package.json was found in "/workspace/logbookmanager_repository".)*

------
https://chatgpt.com/codex/tasks/task_e_68f4725ff1a4832c82858f40378125b4