### PR TITLE
Add parser metadata to column mappings

### DIFF
--- a/demo/demo_rule.yaml
+++ b/demo/demo_rule.yaml
@@ -45,21 +45,27 @@ column_mapping:
     - name: "나이"
       field: "age"
       type: "number"
+      parser: "age"
       aliases: ["AGE", "PATIENT_AGE", "Age"]
       description: "환자의 나이"
     - name: "환자성별"
       field: "sex"
       type: "string"
+      parser: "gender"
       aliases: ["SEX", "PATIENT_SEX", "환자성별(M/F)"]
       description: "환자의 성별 (M 또는 F)"
     - name: "검사일"
       field: "study_date"
       type: "date"
+      parser: "date"
+      format: "YYYY-MM-DD"
       aliases: ["STUDY DATE", "Study DateTime", "STUDY_DATE", "Exam Date(Time)", "검사일(년-월-일)"]
       description: "검사가 수행된 날짜"
     - name: "판독일"
       field: "reading_date"
       type: "date"
+      parser: "date"
+      format: "YYYY-MM-DD"
       aliases: ["DRAFT DATE", "Report Date", "draft_date", "CREATE_DATE", "판독일(년-월-일)"]
       description: "판독 보고서가 작성된 날짜"
   default_order:

--- a/rules.json
+++ b/rules.json
@@ -3,7 +3,7 @@
     "path": "rules/cauhs-2.yaml",
     "title": "중앙대병원-흑석 2022년이후 입국",
     "description": "중앙대학교병원 / Zetta PACS \nrecord2.radiology.or.kr 사이트 이용하는 2022년 이후 입국자\n2023년 개정 logbook 실태조사\n검사종류/검사명/부서/담당구분 기반 분류\n",
-    "updated_at": "2025-10-19T14:13:27+09:00",
+    "updated_at": "2025-10-19T16:04:50+09:00",
     "author": {
       "name": "김영욱",
       "email": "wooooooooooook@gmail.com"
@@ -79,6 +79,7 @@
           "name": "나이",
           "field": "age",
           "type": "number",
+          "parser": "age",
           "aliases": [
             "AGE",
             "PATIENT_AGE",
@@ -90,6 +91,7 @@
           "name": "환자성별",
           "field": "sex",
           "type": "string",
+          "parser": "gender",
           "aliases": [
             "SEX",
             "PATIENT_SEX",
@@ -101,6 +103,8 @@
           "name": "검사일",
           "field": "study_date",
           "type": "date",
+          "parser": "date",
+          "format": "YYYY-MM-DD",
           "aliases": [
             "STUDY DATE",
             "Study DateTime",
@@ -114,6 +118,8 @@
           "name": "판독일",
           "field": "reading_date",
           "type": "date",
+          "parser": "date",
+          "format": "YYYY-MM-DD",
           "aliases": [
             "DRAFT DATE",
             "Report Date",
@@ -139,7 +145,7 @@
     "path": "rules/amc.yaml",
     "title": "서울아산병원-테스트 2022년이후 입국자용",
     "description": "서울아산병원\nrecord2.radiology.or.kr 사이트 이용하는 2022년 이후 입국자\n2023년 개정 logbook 실태조사\n검사종류/검사명/부서/담당구분 기반 분류\n일부 분류 미흡한 버전\n",
-    "updated_at": "2025-10-19T14:13:27+09:00",
+    "updated_at": "2025-10-19T16:04:50+09:00",
     "author": {
       "name": "김영욱",
       "email": "wooooooooooook@gmail.com"
@@ -187,6 +193,8 @@
           "name": "검사일",
           "field": "study_date",
           "type": "date",
+          "parser": "date",
+          "format": "YYYY-MM-DD",
           "aliases": [
             "PACS검사일자"
           ]
@@ -195,6 +203,8 @@
           "name": "판독일",
           "field": "reading_date",
           "type": "date",
+          "parser": "date",
+          "format": "YYYY-MM-DD",
           "aliases": [
             "DICTATEDDATE"
           ]
@@ -205,6 +215,7 @@
           "name": "나이",
           "field": "age",
           "type": "number",
+          "parser": "age",
           "aliases": [
             "AGE",
             "PATIENT_AGE",
@@ -216,6 +227,7 @@
           "name": "환자성별",
           "field": "sex",
           "type": "string",
+          "parser": "gender",
           "aliases": [
             "SEX",
             "PATIENT_SEX",
@@ -238,7 +250,7 @@
     "path": "rules/cauhs-2020.yaml",
     "title": "중앙대병원-흑석 2021년 이전 입국",
     "description": "중앙대학교병원용 / Zetta PACS\nrecord2020.radiology.or.kr 사이트 이용하는 2021년 이전 입국자\n2023년 개정 logbook 실태조사\n검사종류/검사명/부서/담당구분 기반 분류\n",
-    "updated_at": "2025-10-19T14:13:27+09:00",
+    "updated_at": "2025-10-19T16:04:50+09:00",
     "author": {
       "name": "김영욱",
       "email": "wooooooooooook@gmail.com"
@@ -314,6 +326,7 @@
           "name": "나이",
           "field": "age",
           "type": "number",
+          "parser": "age",
           "aliases": [
             "AGE",
             "PATIENT_AGE",
@@ -325,6 +338,7 @@
           "name": "환자성별",
           "field": "sex",
           "type": "string",
+          "parser": "gender",
           "aliases": [
             "SEX",
             "PATIENT_SEX",
@@ -336,6 +350,8 @@
           "name": "검사일",
           "field": "study_date",
           "type": "date",
+          "parser": "date",
+          "format": "YYYY-MM-DD",
           "aliases": [
             "STUDY DATE",
             "Study DateTime",
@@ -349,6 +365,8 @@
           "name": "판독일",
           "field": "reading_date",
           "type": "date",
+          "parser": "date",
+          "format": "YYYY-MM-DD",
           "aliases": [
             "DRAFT DATE",
             "Report Date",

--- a/rules/amc.yaml
+++ b/rules/amc.yaml
@@ -38,20 +38,26 @@ column_mapping:
     - name: "검사일"
       field: "study_date"
       type: "date"
+      parser: "date"
+      format: "YYYY-MM-DD"
       aliases: ["PACS검사일자"]
     - name: "판독일"
       field: "reading_date"
       type: "date"
+      parser: "date"
+      format: "YYYY-MM-DD"
       aliases: ["DICTATEDDATE"]
   optional:
     - name: "나이"
       field: "age"
       type: "number"
+      parser: "age"
       aliases: ["AGE", "PATIENT_AGE", "Age"]
       description: "환자의 나이"
     - name: "환자성별"
       field: "sex"
       type: "string"
+      parser: "gender"
       aliases: ["SEX", "PATIENT_SEX", "환자성별(M/F)"]
       description: "환자의 성별 (M 또는 F)"
   default_order:

--- a/rules/cauhs-2.yaml
+++ b/rules/cauhs-2.yaml
@@ -46,21 +46,27 @@ column_mapping:
     - name: "나이"
       field: "age"
       type: "number"
+      parser: "age"
       aliases: ["AGE", "PATIENT_AGE", "Age"]
       description: "환자의 나이"
     - name: "환자성별"
       field: "sex"
       type: "string"
+      parser: "gender"
       aliases: ["SEX", "PATIENT_SEX", "환자성별(M/F)"]
       description: "환자의 성별 (M 또는 F)"
     - name: "검사일"
       field: "study_date"
       type: "date"
+      parser: "date"
+      format: "YYYY-MM-DD"
       aliases: ["STUDY DATE", "Study DateTime", "STUDY_DATE", "Exam Date(Time)", "검사일(년-월-일)"]
       description: "검사가 수행된 날짜"
     - name: "판독일"
       field: "reading_date"
       type: "date"
+      parser: "date"
+      format: "YYYY-MM-DD"
       aliases: ["DRAFT DATE", "Report Date", "draft_date", "CREATE_DATE", "판독일(년-월-일)"]
       description: "판독 보고서가 작성된 날짜"
   default_order:

--- a/rules/cauhs-2020.yaml
+++ b/rules/cauhs-2020.yaml
@@ -46,21 +46,27 @@ column_mapping:
     - name: "나이"
       field: "age"
       type: "number"
+      parser: "age"
       aliases: ["AGE", "PATIENT_AGE", "Age"]
       description: "환자의 나이"
     - name: "환자성별"
       field: "sex"
       type: "string"
+      parser: "gender"
       aliases: ["SEX", "PATIENT_SEX", "환자성별(M/F)"]
       description: "환자의 성별 (M 또는 F)"
     - name: "검사일"
       field: "study_date"
       type: "date"
+      parser: "date"
+      format: "YYYY-MM-DD"
       aliases: ["STUDY DATE", "Study DateTime", "STUDY_DATE", "Exam Date(Time)", "검사일(년-월-일)"]
       description: "검사가 수행된 날짜"
     - name: "판독일"
       field: "reading_date"
       type: "date"
+      parser: "date"
+      format: "YYYY-MM-DD"
       aliases: ["DRAFT DATE", "Report Date", "draft_date", "CREATE_DATE", "판독일(년-월-일)"]
       description: "판독 보고서가 작성된 날짜"
   default_order:


### PR DESCRIPTION
## Summary
- add parser hints for age, gender, and date fields in the demo rule
- update hospital rule files to declare date formats and parsing strategies

## Testing
- pnpm format && pnpm lint *(fails: No package manifest found)*
- pnpm check *(fails: No package manifest found)*
- pnpm test *(fails: No package manifest found)*

------
https://chatgpt.com/codex/tasks/task_e_68f48a1965d8832c8ddef86cbe8d4109