### PR TITLE
Update sex column mapping to enum

### DIFF
--- a/demo/demo_rule.yaml
+++ b/demo/demo_rule.yaml
@@ -50,7 +50,8 @@ column_mapping:
       description: "환자의 나이"
     - name: "환자성별"
       field: "sex"
-      type: "string"
+      type: "enum"
+      values: ["M", "F", ""]
       parser: "gender"
       aliases: ["SEX", "PATIENT_SEX", "환자성별(M/F)"]
       description: "환자의 성별 (M 또는 F)"

--- a/rules.json
+++ b/rules.json
@@ -3,7 +3,7 @@
     "path": "rules/cauhs-2.yaml",
     "title": "중앙대병원-흑석 2022년이후 입국",
     "description": "중앙대학교병원 / Zetta PACS \nrecord2.radiology.or.kr 사이트 이용하는 2022년 이후 입국자\n2023년 개정 logbook 실태조사\n검사종류/검사명/부서/담당구분 기반 분류\n",
-    "updated_at": "2025-10-19T16:05:18+09:00",
+    "updated_at": "2025-10-19T17:22:15+09:00",
     "author": {
       "name": "김영욱",
       "email": "wooooooooooook@gmail.com"
@@ -90,7 +90,12 @@
         {
           "name": "환자성별",
           "field": "sex",
-          "type": "string",
+          "type": "enum",
+          "values": [
+            "M",
+            "F",
+            ""
+          ],
           "parser": "gender",
           "aliases": [
             "SEX",
@@ -145,7 +150,7 @@
     "path": "rules/amc.yaml",
     "title": "서울아산병원-테스트 2022년이후 입국자용",
     "description": "서울아산병원\nrecord2.radiology.or.kr 사이트 이용하는 2022년 이후 입국자\n2023년 개정 logbook 실태조사\n검사종류/검사명/부서/담당구분 기반 분류\n일부 분류 미흡한 버전\n",
-    "updated_at": "2025-10-19T16:05:18+09:00",
+    "updated_at": "2025-10-19T17:22:15+09:00",
     "author": {
       "name": "김영욱",
       "email": "wooooooooooook@gmail.com"
@@ -226,7 +231,12 @@
         {
           "name": "환자성별",
           "field": "sex",
-          "type": "string",
+          "type": "enum",
+          "values": [
+            "M",
+            "F",
+            ""
+          ],
           "parser": "gender",
           "aliases": [
             "SEX",
@@ -250,7 +260,7 @@
     "path": "rules/cauhs-2020.yaml",
     "title": "중앙대병원-흑석 2021년 이전 입국",
     "description": "중앙대학교병원용 / Zetta PACS\nrecord2020.radiology.or.kr 사이트 이용하는 2021년 이전 입국자\n2023년 개정 logbook 실태조사\n검사종류/검사명/부서/담당구분 기반 분류\n",
-    "updated_at": "2025-10-19T16:05:18+09:00",
+    "updated_at": "2025-10-19T17:22:15+09:00",
     "author": {
       "name": "김영욱",
       "email": "wooooooooooook@gmail.com"
@@ -337,7 +347,12 @@
         {
           "name": "환자성별",
           "field": "sex",
-          "type": "string",
+          "type": "enum",
+          "values": [
+            "M",
+            "F",
+            ""
+          ],
           "parser": "gender",
           "aliases": [
             "SEX",

--- a/rules/amc.yaml
+++ b/rules/amc.yaml
@@ -56,7 +56,8 @@ column_mapping:
       description: "환자의 나이"
     - name: "환자성별"
       field: "sex"
-      type: "string"
+      type: "enum"
+      values: ["M", "F", ""]
       parser: "gender"
       aliases: ["SEX", "PATIENT_SEX", "환자성별(M/F)"]
       description: "환자의 성별 (M 또는 F)"

--- a/rules/cauhs-2.yaml
+++ b/rules/cauhs-2.yaml
@@ -51,7 +51,8 @@ column_mapping:
       description: "환자의 나이"
     - name: "환자성별"
       field: "sex"
-      type: "string"
+      type: "enum"
+      values: ["M", "F", ""]
       parser: "gender"
       aliases: ["SEX", "PATIENT_SEX", "환자성별(M/F)"]
       description: "환자의 성별 (M 또는 F)"

--- a/rules/cauhs-2020.yaml
+++ b/rules/cauhs-2020.yaml
@@ -51,7 +51,8 @@ column_mapping:
       description: "환자의 나이"
     - name: "환자성별"
       field: "sex"
-      type: "string"
+      type: "enum"
+      values: ["M", "F", ""]
       parser: "gender"
       aliases: ["SEX", "PATIENT_SEX", "환자성별(M/F)"]
       description: "환자의 성별 (M 또는 F)"


### PR DESCRIPTION
## Summary
- set the sex column mapping to use an enum with explicit values in the demo rule and available rules

## Testing
- pnpm format && pnpm lint *(fails: No package.json was found in the repository)*
- pnpm check *(fails: No package.json was found in the repository)*
- pnpm test *(fails: No package.json was found in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68f49d47bc24832c9c89de2fb37b24e2