### PR TITLE
docs: revise transform operator guidance

### DIFF
--- a/docs/규칙 파일 작성법/3._내보내기_설정_가이드.md
+++ b/docs/규칙 파일 작성법/3._내보내기_설정_가이드.md
@@ -123,7 +123,54 @@ columns:
 | 속성           | 타입   | 필수/옵션 | 기본값 | 설명                   |
 | -------------- | ------ | --------- | ------ | ---------------------- |
 | `source_field` | string | **필수**  | -      | 변환할 소스 필드       |
-| `function`     | string | **필수**  | -      | JavaScript 함수 문자열 |
+| `default_value` | string/number | 옵션     | -      | 소스 값이 비었을 때 사용할 기본값 |
+| `operations`   | array  | **필수**  | -      | 순차적으로 적용할 변환 연산 목록 |
+
+`transform`은 JavaScript 함수를 직접 작성하는 방식이 아니라, **미리 정의된 연산자들을 순차적으로 적용하는 DSL**로 동작합니다. 각 연산자는 `operations` 배열에 정의한 순서대로 실행됩니다.
+
+###### Transform 연산자 사용법
+
+```yaml
+value:
+  transform:
+    source_field: age
+    operations:
+      - type: case
+        cases:
+          - when:
+              lt: 17
+            value: '소아'
+          - when:
+              gte: 65
+            value: '고령'
+        default: '성인'
+      - type: suffix
+        value: ' 환자'
+```
+
+지원되는 연산자는 다음과 같습니다.
+
+| 유형                                    | 설명                                                                                                                                                                    |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `uppercase`, `lowercase`, `trim`        | 문자열을 대/소문자로 변환하거나 앞뒤 공백 제거                                                                                                                          |
+| `prefix`, `suffix`                      | 문자열 앞/뒤에 값을 붙입니다.                                                                                                                                           |
+| `replace`                               | 단순 문자열 치환 (`search` 전체를 `replace`로 교체).                                                                                                                    |
+| `default`                               | 값이 비어 있을 때 지정된 기본값을 사용합니다.                                                                                                                           |
+| `add`, `subtract`, `multiply`, `divide` | 숫자 연산. `divide`는 `precision` 옵션으로 소수점 반올림을 지정할 수 있습니다.                                                                                          |
+| `round`, `toFixed`                      | 반올림 또는 고정 소수점 문자열 반환.                                                                                                                                    |
+| `map`                                   | 딕셔너리 매핑. 일치 항목이 없으면 `fallback`을 사용할 수 있습니다.                                                                                                      |
+| `case`                                  | 조건에 따라 값을 선택합니다. `when` 조건은 `equals`, `in`, `lt`, `lte`, `gt`, `gte`, `contains`, `regex`를 조합할 수 있으며, 일치 항목이 없으면 `default`가 사용됩니다. |
+
+소스 필드 값이 비어 있을 때 기본값을 지정하려면 `default_value`를 사용할 수 있습니다.
+
+```yaml
+value:
+  transform:
+    source_field: modality
+    default_value: 'UNKNOWN'
+    operations:
+      - type: uppercase
+```
 
 ##### 3.2.6 conditional
 
@@ -210,9 +257,9 @@ columns:
             value: '검사명 없음'
 ```
 
-<!-- #### 4.3 데이터 변환 기능
+#### 4.3 데이터 변환 기능
 
-특정 컬럼에 대해 데이터를 변환할 수 있습니다. `source_field`의 값이 `data`로 전달됩니다:
+특정 컬럼에 대해 데이터를 변환할 수 있습니다. `source_field`에서 가져온 값을 기준으로 순차적인 연산을 적용합니다:
 
 ```yaml
 - age_group:
@@ -223,12 +270,15 @@ columns:
     value:
       transform:
         source_field: 'age'
-        function: |
-          function(data) { 
-            if (data === null || data === undefined) return '';
-            return data < 17 ? '소아' : '성인';
-          }
-``` -->
+        default_value: ''
+        operations:
+          - type: case
+            cases:
+              - when:
+                  lt: 17
+                value: '소아'
+            default: '성인'
+```
 
 ### 5. 자동 증가 번호 생성
 
@@ -324,11 +374,14 @@ csv_export:
             value:
               transform:
                 source_field: 'age'
-                function: |
-                  function(data) { 
-                    if (data === null || data === undefined) return '';
-                    return data < 17 ? '소아' : '성인';
-                  }
+                default_value: ''
+                operations:
+                  - type: case
+                    cases:
+                      - when:
+                          lt: 17
+                        value: '소아'
+                    default: '성인'
 
         # 환자성별 (데이터 필드에서 가져오기)
         - sex:
@@ -380,7 +433,7 @@ csv_export:
 | 일련번호   | auto_increment           | 순차 증가 번호 (자동 생성)        |
 | 검사종류   | from_metadata            | 메타데이터에서 검사 유형 가져오기 |
 | 세부전공   | from_field: assign       | 담당 구분 필드                    |
-| 소아/성인  | transform: age           | 나이 기반 자동 계산               |
+| 소아/성인  | transform (source_field: age) | 나이 기반 자동 계산               |
 | 환자성별   | from_field: sex          | 성별 정보                         |
 | 검사일(년) | from_field: study_date   | 검사 수행일                       |
 | 판독일(년) | from_field: reading_date | 판독 완료일                       |
@@ -426,14 +479,20 @@ csv_export:
     value:
       transform:
         source_field: 'exam_name'
-        function: |
-          function(data) {
-            const examName = data || '';
-            if (examName.includes('CT')) return 'CT';
-            if (examName.includes('MRI')) return 'MRI';
-            if (examName.includes('초음파')) return 'US';
-            return 'OTHER';
-          }
+        default_value: ''
+        operations:
+          - type: case
+            cases:
+              - when:
+                  contains: 'CT'
+                value: 'CT'
+              - when:
+                  contains: 'MRI'
+                value: 'MRI'
+              - when:
+                  contains: '초음파'
+                value: 'US'
+            default: 'OTHER'
 
 # 복합 조건 변환
 - priority_level:
@@ -442,14 +501,17 @@ csv_export:
     value:
       transform:
         source_field: 'age'
-        function: |
-          function(data, row) {
-            const age = data;
-            const modality = row.modality;
-            if (age < 17 && modality === 'CT') return 'HIGH';
-            if (age < 17) return 'MEDIUM';
-            return 'LOW';
-          }
+        operations:
+          - type: case
+            cases:
+              - when:
+                  lt: 17
+                value: 'HIGH'
+              - when:
+                  gte: 17
+                  lte: 64
+                value: 'MEDIUM'
+            default: 'LOW'
 ```
 
 ### 3. 고급 조건부 로직

--- a/rules.json
+++ b/rules.json
@@ -3,7 +3,7 @@
     "path": "rules/amc.yaml",
     "title": "서울아산병원-테스트 2022년이후 입국자용",
     "description": "서울아산병원\nrecord2.radiology.or.kr 사이트 이용하는 2022년 이후 입국자\n2023년 개정 logbook 실태조사\n검사종류/검사명/부서/담당구분 기반 분류\n일부 분류 미흡한 버전\n",
-    "updated_at": "2025-10-25T08:29:39+09:00",
+    "updated_at": "2025-10-25T16:18:44+09:00",
     "author": {
       "name": "김영욱",
       "email": "wooooooooooook@gmail.com"
@@ -116,7 +116,7 @@
     "path": "rules/cauhs-2.yaml",
     "title": "중앙대병원-흑석 2022년이후 입국",
     "description": "중앙대학교병원 / Zetta PACS \nrecord2.radiology.or.kr 사이트 이용하는 2022년 이후 입국자\n2023년 개정 logbook 실태조사\n검사종류/검사명/부서/담당구분 기반 분류\n",
-    "updated_at": "2025-10-25T08:29:39+09:00",
+    "updated_at": "2025-10-25T16:18:44+09:00",
     "author": {
       "name": "김영욱",
       "email": "wooooooooooook@gmail.com"
@@ -269,7 +269,7 @@
     "path": "rules/cauhs-2020.yaml",
     "title": "중앙대병원-흑석 2021년 이전 입국",
     "description": "중앙대학교병원용 / Zetta PACS\nrecord2020.radiology.or.kr 사이트 이용하는 2021년 이전 입국자\n2023년 개정 logbook 실태조사\n검사종류/검사명/부서/담당구분 기반 분류\n",
-    "updated_at": "2025-10-25T08:29:39+09:00",
+    "updated_at": "2025-10-25T16:18:44+09:00",
     "author": {
       "name": "김영욱",
       "email": "wooooooooooook@gmail.com"


### PR DESCRIPTION
## Summary
- describe the new DSL-based transform operator with available operations and default handling
- update transform examples in the export guide to use the operations list instead of inline JavaScript

## Testing
- pnpm format && pnpm lint *(fails: repository has no package manifest)*
- pnpm check *(fails: repository has no package manifest)*
- pnpm test *(fails: repository has no package manifest)*

------
https://chatgpt.com/codex/tasks/task_e_68fc5ed55010832ca22729df87778e46